### PR TITLE
Version 0.3, reworked warping system & saving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.nullapex</groupId>
     <artifactId>WarpX</artifactId>
-    <version>0.2</version>
+    <version>0.3</version>
     <packaging>jar</packaging>
 
     <name>WarpX</name>

--- a/src/main/java/me/nullapex/warpX/WarpX.java
+++ b/src/main/java/me/nullapex/warpX/WarpX.java
@@ -3,25 +3,50 @@ package me.nullapex.warpX;
 import me.nullapex.warpX.commands.SetWarp;
 import me.nullapex.warpX.commands.Warp;
 import me.nullapex.warpX.commands.DelWarp;
-import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.HashMap;
+import java.io.File;
+import java.io.IOException;
 
 public final class WarpX extends JavaPlugin {
-    private final HashMap<String, Location> warps = new HashMap<>();
+    private File warpsFile;
+    private FileConfiguration warpsConfig;
 
     @Override
     public void onEnable() {
         getLogger().info("WarpX enabled!");
 
-        getCommand("setwarp").setExecutor(new SetWarp(warps));
-        getCommand("warp").setExecutor(new Warp(warps));
-        getCommand("delwarp").setExecutor(new DelWarp(warps));
+        createWarpsFile();
+
+        getCommand("setwarp").setExecutor(new SetWarp(this));
+        getCommand("warp").setExecutor(new Warp(this));
+        getCommand("delwarp").setExecutor(new DelWarp(this));
     }
 
     @Override
     public void onDisable() {
         getLogger().info("WarpX disabled!");
+    }
+
+    private void createWarpsFile() {
+        warpsFile = new File(getDataFolder(), "warps.yml");
+        if(!warpsFile.exists()) {
+            saveResource("warps.yml", false);
+        }
+        warpsConfig = YamlConfiguration.loadConfiguration(warpsFile);
+    }
+
+    public FileConfiguration getWarpsConfig() {
+        return warpsConfig;
+    }
+
+    public void saveWarpsConfig() {
+        try {
+            warpsConfig.save(warpsFile);
+        } catch (IOException e) {
+            getLogger().severe("Could not save warps.yml: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/me/nullapex/warpX/commands/DelWarp.java
+++ b/src/main/java/me/nullapex/warpX/commands/DelWarp.java
@@ -1,19 +1,21 @@
 package me.nullapex.warpX.commands;
 
+import me.nullapex.warpX.WarpX;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
 
 public class DelWarp implements CommandExecutor {
-    private final HashMap<String, Location> warps;
+    private final WarpX plugin;
 
-    public DelWarp(HashMap<String, Location> warps) {
-        this.warps = warps;
+    public DelWarp(WarpX plugin) {
+        this.plugin = plugin;
     }
 
     @Override
@@ -30,11 +32,18 @@ public class DelWarp implements CommandExecutor {
         }
 
         String warpName = args[0].toLowerCase();
-        if (warps.remove(warpName) != null) {
-            player.sendMessage(ChatColor.RED + "Warp " + ChatColor.AQUA + warpName + ChatColor.RED + " has been deleted.");
-        } else {
-            player.sendMessage(ChatColor.RED + "Warp " + ChatColor.AQUA + warpName + ChatColor.RED + " not found.");
+
+        FileConfiguration config = plugin.getConfig();
+
+        if(!config.contains(warpName)) {
+            player.sendMessage(ChatColor.RED + "That warp does not exist");
+            return true;
         }
+
+        config.set(warpName, null);
+        plugin.saveConfig();
+
+        player.sendMessage(ChatColor.RED + "Warp " + ChatColor.AQUA + warpName + ChatColor.RED + " has been deleted");
         return true;
     }
 }

--- a/src/main/java/me/nullapex/warpX/commands/SetWarp.java
+++ b/src/main/java/me/nullapex/warpX/commands/SetWarp.java
@@ -1,19 +1,19 @@
 package me.nullapex.warpX.commands;
 
+import me.nullapex.warpX.WarpX;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
-import java.util.HashMap;
-
 public class SetWarp implements CommandExecutor {
-    private final HashMap<String, Location> warps;
+    private final WarpX plugin;
 
-    public SetWarp(HashMap<String, Location> warps) {
-        this.warps = warps;
+    public SetWarp(WarpX plugin) {
+        this.plugin = plugin;
     }
 
     @Override
@@ -24,14 +24,28 @@ public class SetWarp implements CommandExecutor {
         }
 
         Player player = (Player) sender;
+
         if (args.length != 1) {
             player.sendMessage(ChatColor.RED + "Usage: /setwarp <warp name>");
             return true;
         }
 
         String warpName = args[0].toLowerCase();
-        warps.put(warpName, player.getLocation());
+        Location location = player.getLocation();
+        saveWarp(warpName, location);
+
         player.sendMessage(ChatColor.GREEN + "Warp " + ChatColor.AQUA + warpName + ChatColor.GREEN + " has been set.");
         return true;
+    }
+
+    private void saveWarp(String warpName, Location location) {
+        FileConfiguration config = plugin.getWarpsConfig();
+
+        config.set(warpName + ".world", location.getWorld().getName());
+        config.set(warpName + ".x", location.getX());
+        config.set(warpName + ".y", location.getY());
+        config.set(warpName + ".z", location.getZ());
+
+        plugin.saveWarpsConfig();
     }
 }

--- a/src/main/java/me/nullapex/warpX/commands/Warp.java
+++ b/src/main/java/me/nullapex/warpX/commands/Warp.java
@@ -1,19 +1,22 @@
 package me.nullapex.warpX.commands;
 
+import me.nullapex.warpX.WarpX;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
-import java.util.HashMap;
+import java.io.File;
 
 public class Warp implements CommandExecutor {
-    private final HashMap<String, Location> warps;
+    private final WarpX plugin;
 
-    public Warp(HashMap<String, Location> warps) {
-        this.warps = warps;
+    public Warp(WarpX plugin) {
+        this.plugin = plugin;
     }
 
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
@@ -29,14 +32,28 @@ public class Warp implements CommandExecutor {
         }
 
         String warpName = args[0].toLowerCase();
-        Location warp = warps.get(warpName);
-        if (warp == null) {
-            player.sendMessage(ChatColor.RED + "That location does not exist");
+
+        FileConfiguration config = plugin.getConfig();
+
+        if(!config.contains(warpName)) {
+            player.sendMessage(ChatColor.RED + "Warp does not exist");
             return true;
         }
 
-        player.teleport(warp);
-        player.sendMessage(ChatColor.GREEN + "Warp " + ChatColor.AQUA + warpName);
+        String worldName = config.getString(warpName + ".world");
+        double x = config.getDouble(warpName + ".x");
+        double y = config.getDouble(warpName + ".y");
+        double z = config.getDouble(warpName + ".z");
+
+        if (Bukkit.getWorld(worldName) == null) {
+            player.sendMessage(ChatColor.RED + "World " + worldName + " does not exist");
+            return true;
+        }
+
+        Location loc = new Location(Bukkit.getWorld(worldName), x, y, z);
+
+        player.teleport(loc);
+        player.sendMessage(ChatColor.GREEN + "Teleported to " + ChatColor.AQUA + warpName);
         return true;
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: WarpX
-version: '0.2'
+version: '0.3'
 main: me.nullapex.warpX.WarpX
 api-version: '1.21'
 load: STARTUP

--- a/src/main/resources/warps.yml
+++ b/src/main/resources/warps.yml
@@ -1,0 +1,10 @@
+spawn:
+  x: 100.5
+  y: 65.0
+  z: -200.5
+  world: world
+market:
+  x: 150.0
+  y: 70.0
+  z: -250.0
+  world: world


### PR DESCRIPTION
This pull request includes significant changes to the WarpX plugin, focusing on transitioning from using a `HashMap` to a `YAML` file for storing warp locations. The most important changes include updating the version, modifying the main class to handle file operations, and updating command classes to interact with the new configuration system.

### Version Update:
* Updated the plugin version from `0.2` to `0.3` in `pom.xml` and `plugin.yml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9) [[2]](diffhunk://#diff-98201effe40eaf4a0e8826fadd6c5c9d5beaf9d737226b514f0853f44987a67fL2-R2)

### Main Class Modifications:
* Introduced file operations in `WarpX.java` to manage warp locations using `warps.yml`. This includes creating the file, loading configurations, and methods to save configurations.

### Command Class Updates:
* Updated `DelWarp.java`, `SetWarp.java`, and `Warp.java` to use the new `WarpX` plugin instance for managing warp locations instead of a `HashMap`. This involves loading, saving, and deleting warp locations from the YAML configuration. [[1]](diffhunk://#diff-ed6ebec13ec38dc7b76b6fd80c6cce57706b89efcc9a1d0a61f2f02206545049R3-R18) [[2]](diffhunk://#diff-ed6ebec13ec38dc7b76b6fd80c6cce57706b89efcc9a1d0a61f2f02206545049L33-R46) [[3]](diffhunk://#diff-a3ae5687a20a60f563944d2bc09af1d32fe422b5a89ade8cdb2a6624381217d6R3-R16) [[4]](diffhunk://#diff-a3ae5687a20a60f563944d2bc09af1d32fe422b5a89ade8cdb2a6624381217d6R27-R50) [[5]](diffhunk://#diff-644c2415b33902919e63880d6b4fb2392620089e9aaa9628918996e8b4a796acR3-R19) [[6]](diffhunk://#diff-644c2415b33902919e63880d6b4fb2392620089e9aaa9628918996e8b4a796acL32-R56)

### Resource File Addition:
* Added a default `warps.yml` file with initial warp locations (`spawn` and `market`).

These changes ensure that warp locations are now persistent across server restarts and can be easily managed through the YAML configuration file.