### PR TITLE
Version 0.4 - fixed warp bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.nullapex</groupId>
     <artifactId>WarpX</artifactId>
-    <version>0.3</version>
+    <version>0.4</version>
     <packaging>jar</packaging>
 
     <name>WarpX</name>

--- a/src/main/java/me/nullapex/warpX/commands/Warp.java
+++ b/src/main/java/me/nullapex/warpX/commands/Warp.java
@@ -33,17 +33,17 @@ public class Warp implements CommandExecutor {
 
         String warpName = args[0].toLowerCase();
 
-        FileConfiguration config = plugin.getConfig();
+        FileConfiguration warpsConfig = plugin.getWarpsConfig();
 
-        if(!config.contains(warpName)) {
+        if(!warpsConfig.contains(warpName)) {
             player.sendMessage(ChatColor.RED + "Warp does not exist");
             return true;
         }
 
-        String worldName = config.getString(warpName + ".world");
-        double x = config.getDouble(warpName + ".x");
-        double y = config.getDouble(warpName + ".y");
-        double z = config.getDouble(warpName + ".z");
+        String worldName = warpsConfig.getString(warpName + ".world");
+        double x = warpsConfig.getDouble(warpName + ".x");
+        double y = warpsConfig.getDouble(warpName + ".y");
+        double z = warpsConfig.getDouble(warpName + ".z");
 
         if (Bukkit.getWorld(worldName) == null) {
             player.sendMessage(ChatColor.RED + "World " + worldName + " does not exist");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: WarpX
-version: '0.3'
+version: '0.4'
 main: me.nullapex.warpX.WarpX
 api-version: '1.21'
 load: STARTUP


### PR DESCRIPTION
This pull request includes several changes to update the version of the `WarpX` plugin and modify the configuration handling in the `Warp` command. The most important changes include updating the version in multiple files and switching from the general configuration to a specific warps configuration.

Version updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9): Updated the version from `0.3` to `0.4`.
* [`src/main/resources/plugin.yml`](diffhunk://#diff-98201effe40eaf4a0e8826fadd6c5c9d5beaf9d737226b514f0853f44987a67fL2-R2): Updated the version from `0.3` to `0.4`.

Configuration handling improvements:

* [`src/main/java/me/nullapex/warpX/commands/Warp.java`](diffhunk://#diff-644c2415b33902919e63880d6b4fb2392620089e9aaa9628918996e8b4a796acL36-R46): Changed the configuration object from `plugin.getConfig()` to `plugin.getWarpsConfig()` and updated the related code to use `warpsConfig` instead of `config`.